### PR TITLE
[San 33] Add Fullscreen API 

### DIFF
--- a/packages/client/src/pages/gameStart/GameStart.module.scss
+++ b/packages/client/src/pages/gameStart/GameStart.module.scss
@@ -93,3 +93,13 @@
   right: 105px;
   z-index: 2;
 }
+
+.fullScreen {
+  position: absolute;
+  top: 20px;
+  right: 10px;
+  font-size: 24px;
+  color: $color-text-primary;
+  cursor: pointer;
+  z-index: 9999;
+}

--- a/packages/client/src/pages/gameStart/GameStart.tsx
+++ b/packages/client/src/pages/gameStart/GameStart.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react'
+import { FC, useState } from 'react'
 import { Link } from 'react-router-dom'
 
 import linesImg from 'shared/assets/images/Lines.svg'
@@ -6,7 +6,21 @@ import moonsImg from 'shared/assets/images/Moons.svg'
 
 import classes from './GameStart.module.scss'
 
+import { FullscreenExitOutlined, FullscreenOutlined } from '@ant-design/icons'
+
 export const GameStart: FC = () => {
+  const [isFullScreen, setFullScreen] = useState(false)
+
+  const onFullScreen = async () => {
+    if (!document.fullscreenElement) {
+      await document.documentElement.requestFullscreen()
+      setFullScreen(true)
+    } else {
+      await document.exitFullscreen()
+      setFullScreen(false)
+    }
+  }
+
   return (
     <div className={classes.startPageWrapper}>
       <div className={classes.absoluteWrapper}>
@@ -20,6 +34,18 @@ export const GameStart: FC = () => {
       <Link className={classes.startPageWrapperTitle} to="game">
         Start
       </Link>
+
+      {isFullScreen ? (
+        <FullscreenExitOutlined
+          onClick={onFullScreen}
+          className={classes.fullScreen}
+        />
+      ) : (
+        <FullscreenOutlined
+          onClick={onFullScreen}
+          className={classes.fullScreen}
+        />
+      )}
     </div>
   )
 }

--- a/packages/client/src/pages/leaderboard/Leaderboard.tsx
+++ b/packages/client/src/pages/leaderboard/Leaderboard.tsx
@@ -4,19 +4,20 @@ import { LeaderCard } from 'components/LeaderCard'
 
 import classes from './Leaderboard.module.scss'
 
+const leaders: JSX.Element[] = []
 export const Leaderboard: FC = () => {
-  const leaders = []
-
-  for (let i = 0; i < 4; i++) {
-    leaders.push(
-      <LeaderCard key={i} name="Paul Atreides" scores={2828127127} point={1} />
-    )
-  }
-
   return (
     <div className={classes.background}>
       <div className={classes.title}>leaders</div>
-      <div className={classes.flexbox}>{leaders}</div>
+      <div className={classes.flexbox}>
+        {leaders.map((el, idx) => (
+          <LeaderCard
+            key={idx}
+            name="Paul Atreides"
+            scores={2828127127}
+            point={idx}></LeaderCard>
+        ))}
+      </div>
     </div>
   )
 }

--- a/packages/client/src/pages/leaderboard/Leaderboard.tsx
+++ b/packages/client/src/pages/leaderboard/Leaderboard.tsx
@@ -12,10 +12,11 @@ export const Leaderboard: FC = () => {
       <div className={classes.flexbox}>
         {leaders.map((el, idx) => (
           <LeaderCard
-            key={idx}
+            key={`leader index: ${idx}`}
             name="Paul Atreides"
             scores={2828127127}
-            point={idx}></LeaderCard>
+            point={idx}
+          />
         ))}
       </div>
     </div>


### PR DESCRIPTION
Какую задачу решаем: https://github.com/SashaLevkovich/middle.SandwormRampage.praktikum.yandex/issues/42

Скриншоты:
<img width="1728" alt="Снимок экрана 2024-06-05 в 17 42 12" src="https://github.com/SashaLevkovich/middle.SandwormRampage.praktikum.yandex/assets/74641968/fb4c36d5-d50c-4322-b6d8-2d6a5ca8bf7a">

<img width="1728" alt="Снимок экрана 2024-06-05 в 17 42 19" src="https://github.com/SashaLevkovich/middle.SandwormRampage.praktikum.yandex/assets/74641968/45555708-cd10-4493-a73f-904404eaaef3">


TBD:
- Добавила кнопку для входа/выхода в полноэкранный режим на странице начала игры в правом верхнем углу
- В рамках задачи отрефакторила задачу из предыдущего спринта (вёрстка лидерборда). Это файл Leaderboard.tsx